### PR TITLE
Regenerate workflows from shimmer template

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -155,10 +155,10 @@ jobs:
         run: |
           PROMPT_FILE=$(mktemp)
 
-          # Add agent identity — resolve via the home's agent:identity task
-          AGENT_IDENTITY_FILE=$(mise -C "$HOME/$REPO_NAME" run -q agent:identity "${{ inputs.agent }}" 2>/dev/null) || true
-          if [ -n "$AGENT_IDENTITY_FILE" ] && [ -f "$AGENT_IDENTITY_FILE" ]; then
-            cat "$AGENT_IDENTITY_FILE" >> "$PROMPT_FILE"
+          # Add agent identity — resolve via the home's agent:identity task (returns content)
+          AGENT_IDENTITY_CONTENT=$(mise -C "$HOME/$REPO_NAME" run -q agent:identity "${{ inputs.agent }}" 2>/dev/null) || true
+          if [ -n "$AGENT_IDENTITY_CONTENT" ]; then
+            echo "$AGENT_IDENTITY_CONTENT" >> "$PROMPT_FILE"
           else
             echo "Error: could not resolve agent identity for '${{ inputs.agent }}'."
             echo "Does $REPO_NAME provide an agent:identity task?"


### PR DESCRIPTION
## Summary

- Regenerate `agent-run.yml` from the updated shimmer template
- Fixes `agent:identity` resolution — task now returns content instead of a file path, and the workflow template was updated to match (shimmer main)

Without this, all agent runs on den fail with: `Error: could not resolve agent identity for '<agent>'`

## Test plan

- [ ] Trigger an agent run on den and verify it starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)