### PR TITLE
feat: add codebase linting + setup task

### DIFF
--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#MISE description="Set up dev environment (hooks, tools)"
+set -euo pipefail
+
+echo "Setting up $(basename "$MISE_CONFIG_ROOT")..."
+
+if command -v codebase &>/dev/null; then
+  cd "$MISE_CONFIG_ROOT" && codebase pre-commit
+else
+  echo "WARN: codebase not found — run 'mise install' first" >&2
+fi
+
+echo "Done."

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,7 @@
 [settings]
 experimental = true
+quiet = true
+task_output = "interleave"
 
 [plugins]
 shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
@@ -16,6 +18,7 @@ gum = "latest"
 "shiv:secrets" = "0.1.0"                  # Provider-based secret management
 "shiv:emails" = "0.2.0"                   # Email CLI for agents
 "shiv:shell" = "0.1.0"                    # Persistent terminal sessions
+"shiv:codebase" = "0.1.0"                 # Codebase linting + migrations
 
 # git-crypt has no macOS ARM prebuilt binary — install via: rudi install
 
@@ -24,3 +27,9 @@ gum = "latest"
 # Each agent has tasks in agents/<name>/.mise/tasks/
 # Shared tasks go in .mise/tasks/
 # Run `mise tasks` to see available tasks
+
+[_.codebase]
+lint = ["mise-settings", "gum-table"]
+
+[_.codebase.scope]
+gum-table = ".mise/tasks"


### PR DESCRIPTION
Adds codebase lint rules (mise-settings, gum-table) with pre-commit hook.

- `shiv:codebase` as tool dependency
- `[_.codebase]` lint config with scoped gum-table to `.mise/tasks`
- `quiet = true` and `task_output = "interleave"` in settings
- `setup` task installs pre-commit hook

After merging: `mise install && mise run setup`