### PR TITLE
ci: require explicit agent workflow models

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -18,8 +18,8 @@ on:
         required: true
         type: string
       model:
-        description: 'Model to use (optional)'
-        required: false
+        description: 'Provider-qualified model to use (e.g., openai-codex/gpt-5.5)'
+        required: true
         type: string
     secrets:
       ANTHROPIC_API_KEY:
@@ -232,8 +232,17 @@ jobs:
           # Configure gh as git credential helper so shiv can clone private repos
           gh auth setup-git
 
-          CMD=(shimmer agent --headless --timeout "$RUN_TIMEOUT")
-          [ -n "$INPUT_MODEL" ] && CMD+=(--model "$INPUT_MODEL")
+          if [ -z "$INPUT_MODEL" ]; then
+            echo "::error::model input is required"
+            exit 1
+          fi
+
+          if [[ "$INPUT_MODEL" != */* ]]; then
+            echo "::error::model input must be provider-qualified (for example: openai-codex/gpt-5.5)"
+            exit 1
+          fi
+
+          CMD=(shimmer agent --headless --timeout "$RUN_TIMEOUT" --model "$INPUT_MODEL")
           CMD+=("$INPUT_MESSAGE")
 
           "${CMD[@]}"

--- a/.github/workflows/baby-joel.yml
+++ b/.github/workflows/baby-joel.yml
@@ -12,8 +12,8 @@ on:
         required: true
         type: string
       model:
-        description: 'Model to use (optional)'
-        required: false
+        description: 'Provider-qualified model to use (e.g., openai-codex/gpt-5.5)'
+        required: true
         type: string
 
 jobs:

--- a/.github/workflows/ikma.yml
+++ b/.github/workflows/ikma.yml
@@ -12,8 +12,8 @@ on:
         required: true
         type: string
       model:
-        description: 'Model to use (optional)'
-        required: false
+        description: 'Provider-qualified model to use (e.g., openai-codex/gpt-5.5)'
+        required: true
         type: string
 
 jobs:

--- a/.github/workflows/zeke.yml
+++ b/.github/workflows/zeke.yml
@@ -12,8 +12,8 @@ on:
         required: true
         type: string
       model:
-        description: 'Model to use (optional)'
-        required: false
+        description: 'Provider-qualified model to use (e.g., openai-codex/gpt-5.5)'
+        required: true
         type: string
 
 jobs:

--- a/mise.toml
+++ b/mise.toml
@@ -9,8 +9,8 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 [tools]
 usage = "latest"
 gum = "latest"
-"shiv:shimmer" = "latest"                 # Agent orchestration + identity
-"shiv:sessions" = "latest"                 # Session transcripts
+"shiv:shimmer" = "0.1.0"                 # Agent orchestration + identity
+"shiv:sessions" = "0.4.0"                 # Session transcripts
 "shiv:modules" = "latest"                  # Encrypted git submodules
 "shiv:notes" = "latest"                    # Encrypted shared notes
 "shiv:threads" = "latest"

--- a/workflows.yaml
+++ b/workflows.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/KnickKnackLabs/shimmer/v0.1.0/workflows.schema.json
+#
+# Agent workflow schedules for den.
+# Run `shimmer workflows:generate` to regenerate workflow files.
+#
+# Den currently has manual dispatch workflows only; scheduled workflows go here.
+
+workflows: []


### PR DESCRIPTION
## Summary
- pin `shiv:shimmer` to v0.1.0 and `shiv:sessions` to v0.4.0
- regenerate manual agent workflows so `model` is required and provider-qualified
- add an explicit empty `workflows.yaml` manifest so released `shimmer workflows:check` can validate den even though there are no scheduled workflows

## Verification
- `mise exec -- shimmer workflows:generate`
- `mise exec -- shimmer workflows:check`
- `mise exec -- sessions wake --help` shows required provider-qualified `--model`
- `mise exec -- codebase lint:mise-settings "$PWD"`
- `mise exec -- codebase lint:gum-table "$PWD"`
