### PR TITLE
Prepare den child workspaces

### DIFF
--- a/.mise/tasks/agent/prepare
+++ b/.mise/tasks/agent/prepare
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#MISE description="Prepare den for an agent run"
+#
+# Idempotent, non-interactive setup owned by this repo.
+# Convention: fold/notes/agent-prepare-hook.md.
+set -euo pipefail
+
+cd "$MISE_CONFIG_ROOT"
+
+log() { printf '[agent:prepare] %s\n' "$*"; }
+
+trust_shiv_package_config() {
+  local tool="${1:?usage: trust_shiv_package_config <tool>}" root package config
+
+  root=$(mise where "$tool" 2>/dev/null) || return 0
+  package="${tool#shiv:}"
+  config="$root/packages/$package/mise.toml"
+
+  if [ -f "$config" ]; then
+    mise trust "$config" >/dev/null
+  fi
+}
+
+ensure_git_crypt() {
+  if command -v git-crypt >/dev/null 2>&1; then
+    log "git-crypt: already installed"
+    return
+  fi
+
+  log "git-crypt: installing via rudi"
+  rudi install
+}
+
+trust_shiv_package_config shiv:rudi
+trust_shiv_package_config shiv:notes
+trust_shiv_package_config shiv:modules
+
+if [ -f notes/.manifest ]; then
+  ensure_git_crypt
+
+  log "notes: setup/unlock"
+  notes setup --yes --unlock
+
+  log "notes: installing hooks"
+  notes install-hooks
+else
+  log "notes: no notes/.manifest; skipping"
+fi
+
+if [ -f .modules/config ]; then
+  log "modules: unlocking manifest"
+  modules unlock
+
+  log "modules: installing hooks"
+  modules install-hooks
+
+  log "modules: initializing runtime clones"
+  modules init fold
+else
+  log "modules: no .modules/config; skipping"
+fi
+
+log "done"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ In GitHub CI, after cloning an agent's home repo, the workflow runs `mise trust`
 
 `agent:prepare` should be idempotent and safe before every headless session. Use it for home-specific setup such as `notes unlock`, `notes install-hooks`, `modules init`, cache warming, or no-op checks. The home repo must declare any tools the hook uses in its own `mise.toml`; den CI should not hardcode assumptions about notes, rudi, modules, or other optional home systems.
 
+Den also exposes its own minimal `agent:prepare` for child workspaces and home-module delegation. It prepares den itself and initializes the selected runtime fold module; it does not recursively prepare nested modules.
+
 ## Who Lives Here
 
 Run `den agent:list` for the current roster. Each agent has their own home repo with identity, session logs, and working notes.


### PR DESCRIPTION
## Summary

Companion to ricon-family/fold#101.

Adds den's minimal `agent:prepare` hook so agent homes and child workspaces can delegate preparation to den as a selected top-level module.

The task prepares den itself:

- trusts direct shiv package configs it invokes (`rudi`, `notes`, `modules`);
- ensures `git-crypt` is available;
- runs `notes setup --yes --unlock`;
- installs notes hooks;
- unlocks `.modules/manifest`;
- installs modules hooks;
- initializes the selected runtime fold module.

It does not recursively prepare nested modules.

## Validation

- `bash -n .mise/tasks/agent/prepare`
- `mise run agent:prepare` in the PR clone
- cold clone of this branch under `/tmp/c0da.d/den-agent-prepare-branch-smoke/den`, then `mise trust && mise install && mise run agent:prepare`
- `mise run test` — 22/22
- `codebase lint:mise-settings "$repo"`
- `codebase lint:gum-table "$repo"`
- `git diff --check HEAD~1..HEAD`
- `notes status` clean
- `git pre-commit`
- `git pre-push` — warning only: new branch initially had no upstream before push
