### PR TITLE
ci: enforce configured codebase lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  codebase-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up mise
+        uses: jdx/mise-action@v4
+        with:
+          install: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run configured codebase lints
+        env:
+          MISE_JOBS: 1
+        run: |
+          set -euo pipefail
+          mise trust
+          mise install
+          codebase lint "$PWD"

--- a/.mise/tasks/agent/env
+++ b/.mise/tasks/agent/env
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #MISE description="Output environment variables for an agent"
-#USAGE arg "[agent]" help="Agent name (defaults to GIT_AUTHOR_NAME)"
-set -eo pipefail
+#USAGE arg "[agent]" default="" help="Agent name (defaults to GIT_AUTHOR_NAME)"
+set -euo pipefail
 
-AGENT="${usage_agent:-$GIT_AUTHOR_NAME}"
+AGENT="${usage_agent:-${GIT_AUTHOR_NAME:-}}"
 
 if [ -z "$AGENT" ]; then
   echo "Error: no agent specified and GIT_AUTHOR_NAME not set" >&2
@@ -12,9 +12,18 @@ if [ -z "$AGENT" ]; then
   exit 1
 fi
 
-# Validate agent exists in this home
-AGENTS=$(mise run -q agent:list 2>/dev/null) || true
-if [ -n "$AGENTS" ] && ! echo "$AGENTS" | grep -qx "$AGENT"; then
+# Validate agent exists in this home when identity notes are readable.
+# agent:env is commonly evaluated during early startup, so locked/missing notes
+# are a degraded probe rather than a hard failure; make that degradation visible.
+AGENT_LIST_ERR=$(mktemp)
+trap 'rm -f "$AGENT_LIST_ERR"' EXIT
+if ! AGENTS=$(mise run -q agent:list 2>"$AGENT_LIST_ERR"); then
+  echo "Warning: unable to validate agent '$AGENT' against den agent:list; continuing with unvalidated agent env." >&2
+  if [ -s "$AGENT_LIST_ERR" ]; then
+    sed 's/^/  /' "$AGENT_LIST_ERR" >&2
+  fi
+  AGENTS=""
+elif [ -n "$AGENTS" ] && ! echo "$AGENTS" | grep -qx "$AGENT"; then
   echo "Error: unknown agent '$AGENT'" >&2
   exit 1
 fi

--- a/.mise/tasks/welcome
+++ b/.mise/tasks/welcome
@@ -149,7 +149,7 @@ fi
 if [ -n "$HUMAN_FILE" ] && [ -f "$HUMAN_FILE" ]; then
   thread_summary=$(threads status --file "$HUMAN_FILE" 2>/dev/null || echo "")
   section "📝 HUMAN.md  ($thread_summary)"
-  if ! threads list --file "$HUMAN_FILE" 2>/dev/null; then
+  if ! threads ls --file "$HUMAN_FILE" 2>/dev/null; then
     gum style --foreground 214 "⚠ unable to list HUMAN.md threads"
   fi
 else

--- a/.mise/tasks/welcome
+++ b/.mise/tasks/welcome
@@ -114,7 +114,15 @@ printf "Branch,Remote,Issues,Encryption,Notes\n%s,%s,%s,%s,%s\n" \
 
 # ━━━ Residents ━━━
 section "Residents"
-agents=$(cd "$DEN_DIR" && mise run -q agent:list 2>/dev/null || true)
+agent_list_err=$(mktemp)
+if ! agents=$(cd "$DEN_DIR" && mise run -q agent:list 2>"$agent_list_err"); then
+  gum style --foreground 214 "⚠ agent:list unavailable; residents omitted"
+  if [ -s "$agent_list_err" ]; then
+    sed 's/^/  /' "$agent_list_err" >&2
+  fi
+  agents=""
+fi
+rm -f "$agent_list_err"
 if [ -n "$agents" ]; then
   resident_rows=""
   while IFS= read -r name; do
@@ -128,15 +136,27 @@ if [ -n "$agents" ]; then
 fi
 
 # ━━━ HUMAN.md ━━━
-HUMAN_FILE=$(cd "$DEN_DIR" && mise run -q human 2>/dev/null || true)
+human_err=$(mktemp)
+if [ -z "${HUMAN_MD:-}" ]; then
+  HUMAN_FILE=""
+elif ! HUMAN_FILE=$(cd "$DEN_DIR" && mise run -q human 2>"$human_err"); then
+  gum style --foreground 214 "⚠ unable to resolve HUMAN.md path" >&2
+  if [ -s "$human_err" ]; then
+    sed 's/^/  /' "$human_err" >&2
+  fi
+  HUMAN_FILE=""
+fi
 if [ -n "$HUMAN_FILE" ] && [ -f "$HUMAN_FILE" ]; then
   thread_summary=$(threads status --file "$HUMAN_FILE" 2>/dev/null || echo "")
   section "📝 HUMAN.md  ($thread_summary)"
-  threads list --file "$HUMAN_FILE" 2>/dev/null || true
+  if ! threads list --file "$HUMAN_FILE" 2>/dev/null; then
+    gum style --foreground 214 "⚠ unable to list HUMAN.md threads"
+  fi
 else
   section "📝 HUMAN.md"
   gum style --faint "(HUMAN_MD not set — see: mise run human)"
 fi
+rm -f "$human_err"
 
 # ━━━ Chat ━━━
 section "💬 Chat"
@@ -180,7 +200,9 @@ if [ -d "$DEN_DIR/modules" ]; then
     name=$(basename "$mod_path")
 
     # Pin freshness
-    git -C "$mod_path" fetch -q 2>/dev/null || true
+    if ! git -C "$mod_path" fetch -q 2>/dev/null; then
+      gum style --foreground 214 "⚠ ${name}: could not refresh origin before pin freshness check" >&2
+    fi
     default_branch=$(git -C "$mod_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
     default_branch=${default_branch:-main}
     behind=$(git -C "$mod_path" rev-list --count "HEAD..origin/${default_branch}" 2>/dev/null || echo 0)
@@ -196,8 +218,11 @@ if [ -d "$DEN_DIR/modules" ]; then
     elif [ -f "$mod_path/.git/hooks/pre-commit" ]; then
       hook_status="✓ installed"
     else
-      (cd "$mod_path" && notes install-hooks >/dev/null 2>&1) || true
-      hook_status="⚠ installed (was missing)"
+      if cd "$mod_path" && notes install-hooks >/dev/null 2>&1; then
+        hook_status="⚠ installed (was missing)"
+      else
+        hook_status="⚠ install failed → cd modules/${name} && notes install-hooks"
+      fi
     fi
 
     module_rows+="${name},${pin_status},${hook_status}"$'\n'


### PR DESCRIPTION
## Summary

Closes #39.

- Adds a normal `CI` workflow on `pull_request` and `push` to `main` that installs den's declared tools and runs the configured aggregate: `codebase lint "$PWD"`.
- Makes `agent:env`'s `agent:list` validation an explicit degraded probe: startup still emits the env export, but stderr now says when identity validation could not run.
- Replaces the clearest `welcome` suppressions with visible degraded behavior for `agent:list`, `HUMAN.md` thread listing, module fetch, and `notes install-hooks`.

## Intentionally left for later

- I did not broaden this into a repo-wide `|| true` cleanup. Remaining suppressions in generated workflows, notes audit/welcome, and okwai guard scaffolding are outside this issue's `agent/env` + `welcome` scope.
- I did not add `or-true` to den's configured lint list; this PR only enforces den's existing configured aggregate (`mise-settings`, `gum-table`).

## Validation

- `codebase lint "$PWD"` — passed.
- `codebase lint:github-actions "$PWD"` — passed; all 6 workflows valid.
- `bash -n .mise/tasks/agent/env .mise/tasks/welcome` and `git diff --check` — passed.
- `mise run welcome >/tmp/den-welcome.out` — passed.
- `mise run agent:env zeke` — passed.

Degraded local test validation: `mise run test` did not execute tests in this environment because the mise-installed BATS runner fails before test execution with `bats-exec-file: command not found` (`Executed 0 instead of expected 22 tests`). Retried after `MISE_JOBS=1 mise install bats`; same failure. No encrypted-note/key blocker was hit for the lints/smokes above.
