### PR TITLE
fix: use current threads list command in welcome

### DIFF
--- a/.mise/tasks/welcome
+++ b/.mise/tasks/welcome
@@ -149,7 +149,7 @@ fi
 if [ -n "$HUMAN_FILE" ] && [ -f "$HUMAN_FILE" ]; then
   thread_summary=$(threads status --file "$HUMAN_FILE" 2>/dev/null || echo "")
   section "📝 HUMAN.md  ($thread_summary)"
-  if ! threads list --file "$HUMAN_FILE" 2>/dev/null; then
+  if ! threads ls --file "$HUMAN_FILE" 2>/dev/null; then
     gum style --foreground 214 "⚠ unable to list HUMAN.md threads"
   fi
 else


### PR DESCRIPTION
Fix-it for #40.

## Summary
- replace stale `threads list` invocation in `welcome` with current `threads ls`
- keeps #40's new visible failure handling, but avoids surfacing a known-bad command as a normal warning

## Validation
- `bash -n .mise/tasks/welcome`
- `shellcheck -x .mise/tasks/welcome`
- `codebase lint "$PWD"`
- `threads ls --file "$HUMAN_FILE"`
- `mise run welcome` smoke; confirmed it no longer prints `unable to list HUMAN.md threads`
