### PR TITLE
agent: slim prepare notes unlock path

### DIFF
--- a/.mise/tasks/agent/prepare
+++ b/.mise/tasks/agent/prepare
@@ -53,8 +53,8 @@ trust_shiv_package_config shiv:modules
 if [ -f notes/.manifest ]; then
   ensure_git_crypt
 
-  log "notes: setup/unlock"
-  notes setup --yes --unlock
+  log "notes: unlocking"
+  notes unlock
 
   log "notes: installing hooks"
   notes install-hooks --yes


### PR DESCRIPTION
## Summary
- use `notes unlock` instead of `notes setup --yes --unlock` during warm agent preparation
- keep the existing `AGENT_PREPARE_REPO_MODULES` selector behavior intact

This matches the fold cleanup: `notes setup --unlock` already installs hooks, so using it immediately before `notes install-hooks --yes` creates duplicated hook output and does more setup work than the warm prepare path needs.

## Validation
- `mise run agent:prepare`
- `mise run agent:smoke`
- `bash -n .mise/tasks/agent/prepare`
