### PR TITLE
deps: adopt Notes 0.9 and Codebase 0.4

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -17,15 +17,16 @@ jq = "latest"                              # JSON manipulation; used by sessions
 "shiv:shimmer" = "0.1"                   # Agent orchestration + identity
 "shiv:sessions" = "0.4"                   # Session transcripts
 "shiv:modules" = "0.9.5"                  # Encrypted git submodules
-"shiv:notes" = "0.8"                      # Encrypted shared notes
+"shiv:notes" = "0.9"                      # Encrypted shared notes
 "shiv:threads" = "0.3.0"
 "shiv:rudi" = "latest"                     # git-crypt wrapper — CI calls rudi install directly
 "shiv:secrets" = "latest"                  # Provider-based secret management
 "shiv:emails" = "0.7"                   # Email CLI for agents
-"shiv:codebase" = "0.3.0"                 # Codebase linting + migrations
+"shiv:codebase" = "0.4"                   # Codebase linting + migrations
 "shiv:farts" = "latest"                    # Frontmatter queries for agent:list
 
 [_.codebase]
+name = "den"
 lint = ["mise-settings", "gum-table"]
 
 [_.codebase.scope]

--- a/test/setup_suite.bash
+++ b/test/setup_suite.bash
@@ -14,4 +14,10 @@ setup_suite() {
   # Load this repo's mise env so tests get the right tool versions regardless
   # of entry point. Requires `mise trust` for this repo.
   eval "$(cd "$REPO_DIR" && mise env)"
+
+  # Bats invokes internal helpers by name after setup_suite runs.
+  # Keep its libexec directory visible when mise env rewrites PATH.
+  if [ -n "${BATS_LIBEXEC:-}" ]; then
+    export PATH="$BATS_LIBEXEC:$PATH"
+  fi
 }


### PR DESCRIPTION
## Summary

- track the released Notes 0.9 minor stream
- track the released Codebase 0.4 minor stream
- declare Den's stable Codebase name
- preserve Bats' internal helper path after `mise env` rewrites the test environment

## Validation

- `mise install` selected Notes 0.9.0 and Codebase 0.4.0
- `mise run agent:prepare`
- `mise welcome`
- `codebase lint .`
- `mise run test` (22 BATS)
- Fold pre-commit and pre-push checks

## Observed setup friction

The pre-existing Den test setup dropped Bats' own libexec path after loading Mise, so no test file could start. This PR applies the established Bats 1.13 environment-preservation pattern and restores the full green suite.
